### PR TITLE
Remove OS indicator on non-windows operating systems 

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1436,12 +1436,12 @@ impl eframe::App for App {
 					#[cfg(target_os = "windows")]
 					if self.admin {
 						ui.add_sized([width, height], Label::new(self.os));
+						ui.separator();
 					} else {
 						ui.add_sized([width, height], Label::new(RichText::new(self.os).color(RED))).on_hover_text(WINDOWS_NOT_ADMIN);
+						ui.separator();
 					}
-					#[cfg(target_family = "unix")]
-					ui.add_sized([width, height], Label::new(self.os));
-					ui.separator();
+
 					// [P2Pool/XMRig] Status
 					use ProcessState::*;
 					match p2pool_state {


### PR DESCRIPTION
The OS indicator on the bottom bar is redundant for many users, because users already know what operating system they are running.

For consistency, a future change could be to move the windows administrator status to the Status page instead of on the bottom bar.