### PR TITLE
[feature] Background + tray icon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1988,6 +1988,7 @@ dependencies = [
  "tokio",
  "toml 0.5.11",
  "tor-rtcompat",
+ "trayicon",
  "walkdir",
  "winres",
  "zeroize",
@@ -5048,6 +5049,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "trayicon"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c367fd7cdcdf19234aa104f7e03abe1be526018e4282af9f275bf436b9c9ad23"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ walkdir = "2.3.2"
 zeroize = "1.5.7"
 serde-xml-rs = "0.6.0"
 strsim = "0.10.0"
+trayicon = "0.1.3"
 
 # Unix dependencies
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
Windows only, using [`trayicon`](https://github.com/ciantic/trayicon-rs).

Either `winit` or `egui-winit` probably needs to be used directly instead of `eframe`.