### PR TITLE
Add custom panic handler

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,7 @@ mod regex;
 mod xmr;
 mod macros;
 mod free;
+mod panic;
 use {macros::*,crate::regex::*,ferris::*,constants::*,node::*,disk::*,update::*,gupax::*,helper::*};
 
 // Sudo (dummy values for Windows)
@@ -1116,9 +1117,16 @@ fn cmp_f64(a: f64, b: f64) -> std::cmp::Ordering {
 //---------------------------------------------------------------------------------------------------- Main [App] frame
 fn main() {
 	let now = Instant::now();
+
+	// Set custom panic hook.
+	crate::panic::set_panic_hook(now);
+
+	// Init logger.
 	init_logger(now);
 	let mut app = App::new(now);
 	init_auto(&mut app);
+
+	// Init GUI stuff.
 	let selected_width = app.state.gupax.selected_width as f32;
 	let selected_height = app.state.gupax.selected_height as f32;
 	let initial_window_size = if selected_width > APP_MAX_WIDTH || selected_height > APP_MAX_HEIGHT {
@@ -1128,10 +1136,14 @@ fn main() {
 		Some(Vec2::new(app.state.gupax.selected_width as f32, app.state.gupax.selected_height as f32))
 	};
 	let options = init_options(initial_window_size);
+
+	// Gupax folder cleanup.
 	match clean_dir() {
 		Ok(_) => info!("Temporary folder cleanup ... OK"),
 		Err(e) => warn!("Could not cleanup [gupax_tmp] folders: {}", e),
 	}
+
+	// Run Gupax.
 	info!("/*************************************/ Init ... OK /*************************************/");
 	eframe::run_native(&app.name_version.clone(), options, Box::new(|cc| Box::new(App::cc(cc, app))),);
 }

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -1,0 +1,50 @@
+//---------------------------------------------------------------------------------------------------- Use
+use crate::constants::{
+	GUPAX_VERSION,
+	P2POOL_VERSION,
+	XMRIG_VERSION,
+	OS_NAME,
+	COMMIT,
+};
+
+//----------------------------------------------------------------------------------------------------
+/// Set custom panic hook.
+pub(crate) fn set_panic_hook(now: std::time::Instant) {
+	std::panic::set_hook(Box::new(move |panic_info| {
+		// Set stack-trace.
+		let stack_trace = std::backtrace::Backtrace::force_capture();
+		let args = std::env::args_os();
+		let uptime = now.elapsed().as_secs_f32();
+
+		// Re-format panic info.
+		let panic_info = format!(
+"{panic_info:#?}
+
+info:
+   OS      | {OS_NAME}
+   args    | {args:?}
+   commit  | {COMMIT}
+   gupax   | {GUPAX_VERSION}
+   p2pool  | {P2POOL_VERSION} (bundled)
+   xmrig   | {XMRIG_VERSION} (bundled)
+   uptime  | {uptime} seconds
+
+stack backtrace:\n{stack_trace}",
+		);
+
+		// Attempt to write panic info to disk.
+		match crate::disk::get_gupax_data_path() {
+			Ok(mut path) => {
+				path.push("crash.txt");
+				match std::fs::write(&path, &panic_info) {
+					Ok(_)  => eprintln!("\nmass_panic!() - Saved panic log to: {}\n", path.display()),
+					Err(e) => eprintln!("\nmass_panic!() - Could not save panic log: {e}\n"),
+				}
+			},
+			Err(e) => eprintln!("panic_hook PATH error: {e}"),
+		}
+
+		// Exit all threads.
+		benri::mass_panic!(panic_info);
+	}));
+}


### PR DESCRIPTION
On crashes (panics only), this will:

- Capture the stack trace
- Add addition information (OS, version, uptime, etc)
- Print the info to STDERR
- `mass_panic!()` all threads (aborts process)

and write it to `crash.txt` inside the Gupax folder on disk.

| OS       | Path |
|----------|------|
| Windows  | `C:\Users\USER\AppData\Roaming\Gupax\crash.txt`           |
| macOS    | `/Users/USER/Library/Application Support/Gupax/crash.txt` |
| Linux    | `/home/USER/.local/share/gupax/crash.txt`                 |