### PR TITLE
Fix ANSI escape sequences at beginning of PTY start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v1.3.4
 # Fixes
 * Domain parsing is more relaxed, allows subdomains with longer TLDs (thanks @soupslurpr [#67](https://github.com/hinto-janai/gupax/pull/67))
+* ANSI escape sequences in Windows P2Pool/XMRig terminal output ([#71](https://github.com/hinto-janai/gupax/pull/71))
 
 ## Bundled Versions
 * [`P2Pool v3.9`](https://github.com/SChernykh/p2pool/releases/tag/v3.9)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,6 +2238,7 @@ dependencies = [
  "serde",
  "serde_json",
  "static_vcruntime",
+ "strip-ansi-escapes",
  "strsim",
  "sudo",
  "sysinfo",
@@ -4641,6 +4642,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ff8ef943b384c414f54aefa961dd2bd853add74ec75e7ac74cf91dba62bcfa"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5840,6 +5850,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5868,6 +5884,26 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "vte"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
+dependencies = [
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "waker-fn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ tor-rtcompat = "0.9.0"
 walkdir = "2.3.3"
 zeroize = "1.6.0"
 strsim = "0.10.0"
+strip-ansi-escapes = "0.2.0"
 
 # Unix dependencies
 [target.'cfg(unix)'.dependencies]

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -273,15 +273,18 @@ impl Helper {
 		let mut stdout = std::io::BufReader::new(reader).lines();
 
 		// Run a ANSI escape sequence filter for the first few lines.
-		for (i, line) in stdout.next().enumerate() {
-			let Some(Ok(line)) = line else { continue; }
+		let mut i = 0;
+		while let Some(Ok(line)) = stdout.next() {
 			let line = strip_ansi_escapes::strip_str(line);
 			if let Err(e) = writeln!(lock!(output_parse), "{}", line) { error!("XMRig PTY Parse | Output error: {}", e); }
 			if let Err(e) = writeln!(lock!(output_pub), "{}", line) { error!("XMRig PTY Pub | Output error: {}", e); }
 			if i > 20 {
 				break;
+			} else {
+				i += 1;
 			}
 		}
+		drop(i);
 
 		while let Some(Ok(line)) = stdout.next() {
 //			println!("{}", line); // For debugging.
@@ -295,15 +298,18 @@ impl Helper {
 		let mut stdout = std::io::BufReader::new(reader).lines();
 
 		// Run a ANSI escape sequence filter for the first few lines.
-		for (i, line) in stdout.next().enumerate() {
-			let Some(Ok(line)) = line else { continue; }
+		let mut i = 0;
+		while let Some(Ok(line)) = stdout.next() {
 			let line = strip_ansi_escapes::strip_str(line);
 			if let Err(e) = writeln!(lock!(output_parse), "{}", line) { error!("P2Pool PTY Parse | Output error: {}", e); }
 			if let Err(e) = writeln!(lock!(output_pub), "{}", line) { error!("P2Pool PTY Pub | Output error: {}", e); }
 			if i > 20 {
 				break;
+			} else {
+				i += 1;
 			}
 		}
+		drop(i);
 
 		while let Some(Ok(line)) = stdout.next() {
 //			println!("{}", line); // For debugging.

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -271,6 +271,18 @@ impl Helper {
 	fn read_pty_xmrig(output_parse: Arc<Mutex<String>>, output_pub: Arc<Mutex<String>>, reader: Box<dyn std::io::Read + Send>) {
 		use std::io::BufRead;
 		let mut stdout = std::io::BufReader::new(reader).lines();
+
+		// Run a ANSI escape sequence filter for the first few lines.
+		for (i, line) in stdout.next().enumerate() {
+			let Some(Ok(line)) = line else { continue; }
+			let line = strip_ansi_escapes::strip_str(line);
+			if let Err(e) = writeln!(lock!(output_parse), "{}", line) { error!("XMRig PTY Parse | Output error: {}", e); }
+			if let Err(e) = writeln!(lock!(output_pub), "{}", line) { error!("XMRig PTY Pub | Output error: {}", e); }
+			if i > 20 {
+				break;
+			}
+		}
+
 		while let Some(Ok(line)) = stdout.next() {
 //			println!("{}", line); // For debugging.
 			if let Err(e) = writeln!(lock!(output_parse), "{}", line) { error!("XMRig PTY Parse | Output error: {}", e); }
@@ -281,6 +293,18 @@ impl Helper {
 	fn read_pty_p2pool(output_parse: Arc<Mutex<String>>, output_pub: Arc<Mutex<String>>, reader: Box<dyn std::io::Read + Send>, gupax_p2pool_api: Arc<Mutex<GupaxP2poolApi>>) {
 		use std::io::BufRead;
 		let mut stdout = std::io::BufReader::new(reader).lines();
+
+		// Run a ANSI escape sequence filter for the first few lines.
+		for (i, line) in stdout.next().enumerate() {
+			let Some(Ok(line)) = line else { continue; }
+			let line = strip_ansi_escapes::strip_str(line);
+			if let Err(e) = writeln!(lock!(output_parse), "{}", line) { error!("P2Pool PTY Parse | Output error: {}", e); }
+			if let Err(e) = writeln!(lock!(output_pub), "{}", line) { error!("P2Pool PTY Pub | Output error: {}", e); }
+			if i > 20 {
+				break;
+			}
+		}
+
 		while let Some(Ok(line)) = stdout.next() {
 //			println!("{}", line); // For debugging.
 			if P2POOL_REGEX.payout.is_match(&line) {


### PR DESCRIPTION
Only seems to happen on Windows.

Fixes https://github.com/hinto-janai/gupax/issues/34.