### PR TITLE
Fix flickering XMRig uptime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
+# v1.3.5
+## Fixes
+* Fix flickering `0s` XMRig uptime (thanks @Tomoyukiryu & @Burner8 [#77](https://github.com/hinto-janai/gupax/pull/77))
+
+## Bundled Versions
+* [`P2Pool v3.10`](https://github.com/SChernykh/p2pool/releases/tag/v3.10)
+* [`XMRig v6.21.0`](https://github.com/xmrig/xmrig/releases/tag/v6.21.0)
+
+
+---
+
+
 # v1.3.4
-# Fixes
+## Fixes
 * Domain parsing is more relaxed, allows subdomains with longer TLDs (thanks @soupslurpr [#67](https://github.com/hinto-janai/gupax/pull/67))
 * ANSI escape sequences in Windows P2Pool/XMRig terminal output ([#71](https://github.com/hinto-janai/gupax/pull/71))
 * P2Pool appearing green (synchronized) on false-positives ([#75](https://github.com/hinto-janai/gupax/pull/75))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2018,7 +2018,7 @@ dependencies = [
 
 [[package]]
 name = "gupax"
-version = "1.3.3"
+version = "1.3.4"
 dependencies = [
  "anyhow",
  "arti-client",

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1930,9 +1930,12 @@ impl PubXmrigApi {
 	) {
 		// 1. Take the process's current output buffer and combine it with Pub (if not empty)
 		let mut output_pub = lock!(output_pub);
-		if !output_pub.is_empty() {
+
+		{
 			let mut public = lock!(public);
-			public.output.push_str(&std::mem::take(&mut *output_pub));
+			if !output_pub.is_empty() {
+				public.output.push_str(&std::mem::take(&mut *output_pub));
+			}
 			// Update uptime
 			public.uptime = HumanTime::into_human(elapsed);
 		}


### PR DESCRIPTION
Fixes https://github.com/hinto-janai/gupax/issues/46
Fixes https://github.com/hinto-janai/gupax/issues/52

Introduced in https://github.com/hinto-janai/gupax/commit/1fcb82718165d83d7d46f83b69fcbf2afb55b2e0#diff-3d0f0f96e2b1cfdd5e6796aff8141648114a917d7ff1de53a0d8f88248418088L1804-L1810.

Combination of issues led to flickering 0s uptime:
1. Uptime update was moved within "if terminal output updated" branch
2. Uptime gets `std::mem::take()`'en which leaves it in `0s` state in-between terminal updates (it should have unconditionally been set to the correct value per call)