### PR TITLE
main: fix central panel cover up the bottom

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2412,6 +2412,7 @@ impl eframe::App for App {
 			self.width = ui.available_width();
 			self.height = ui.available_height();
 			ui.style_mut().override_text_style = Some(TextStyle::Body);
+        egui::ScrollArea::vertical().show(ui, |ui| {
 			match self.tab {
 				Tab::About => {
 					debug!("App | Entering [About] Tab");
@@ -2543,6 +2544,7 @@ path_xmr: {:#?}\n
 					crate::disk::Xmrig::show(&mut self.state.xmrig, &mut self.pool_vec, &self.xmrig, &self.xmrig_api, &mut self.xmrig_stdin, self.width, self.height, ctx, ui);
 				}
 			}
+        });
 		});
     }
 }


### PR DESCRIPTION
## A picture tells a thousand words
**Gupax simple mode**

![Ảnh chụp màn hình (4)](https://github.com/user-attachments/assets/6630665f-aa8c-4ee6-98a5-91470667aa2a)

**Gupax advanced mode**

![Ảnh chụp màn hình (5)](https://github.com/user-attachments/assets/386e7a1a-52c9-49b6-944a-ab64c8a3af2e)

**Fixed Gupax advanced mode**

![Ảnh chụp màn hình (9)](https://github.com/user-attachments/assets/5347dc17-1377-49bd-95bd-a5b5589062aa)

## Before this PR
When switch to advanced mode, the advanced arguments would make the central panel overflow and cover up the bottom panel. This issues affects Gupax, P2Pool, and XMRig tabs.

## After this PR
Wrap the inside of the central panel in a ScrollArea, so it don't overflow.